### PR TITLE
fixed App/integrals

### DIFF
--- a/App/integrals/data.js
+++ b/App/integrals/data.js
@@ -3,25 +3,25 @@
 // integrals : [積分, 解説のリンク]
 // 解説のリンク : 0 -> 準備中
 
-export data = [
-  [`\int_0^{\frac{\pi}2}\cos\log\tan x \ dx`, 0],
-  [`\int_0^\infty\frac{e^{\frac16x}+e^{\frac56x}-2e^{\frac12x}}{x(e^x-1)}\ dx`, 0],
-  [`\int_0^\infty\frac{x^2e^{\frac12x}}{e^x+1}\ dx`, 0],
-  [`\int_0^\infty\frac{1-\text{tanh}x}{\sqrt{\text{tanh}x}}\ dx`, 0],
-  [`\int_0^\infty\frac{\sin \log \tan x}{\log \tan x}\ dx`, 0],
-  [`\int_0^\infty\frac1{\sqrt{x}(x+1)}\ dx`, 0],
-  [`\int_0^1 \frac{\log x}{\sqrt{x}(1+x)}\ dx`, 0],
-  [`\int\prod_{i=0}^n\frac1{\log^ix}\ dx`, 0],
-  [`\int_0^{\frac{\pi}2}\frac{\cos \log \tan x\log \cos x}{\sin^2 x} \ dx`, 0],
-  [`\int_0^1 x\log \log \frac1x \ dx`, 0],
-  [`\int_{\frac{\pi}4}^{\frac{\pi}2}\frac{\cos x\sqrt{\log \tan x}}{\sin^3x}\ dx`, 0],
-  [`\int_0^\infty\frac{\log x\log (1+x)}{x(1+x)}\ dx`, 0],
-  [`\int_0^1 \frac{\log x\log (1+x)}{x(1-x)}\ dx`, 0],
-  [`\int_0^{\frac{\pi}2}\frac{\log \cos x}{\tan x}\ dx`, 0],
-  [`\int_0^\infty\frac{x\log \text{tanh}x}{\text{tanh}x }\ dx`, 0],
-  [`\int_0^{\frac1{\sqrt{3}}}\frac{x\text{arctan}x}{(1-x^2)\sqrt{1-2x^2}}\ dx`, 0],
-  [`\int_0^{\pi}\log\left(\frac54+\cos x\right)\ dx`, 0],
-  [`\int_0^\infty\sqrt{-\log(1-e^x)}\ dx`, 0],
-  [`\int_0^2\frac1{(x+2)\sqrt{x+1}} dx`, 0],
-  [`\int_1^2 \frac1{x\sqrt{1-\log^2x}} dx`, 0]
+export let data = [
+  [String.raw`\int_0^{\frac{\pi}2}\cos\log\tan x \ dx`, 0],
+  [String.raw`\int_0^\infty\frac{e^{\frac16x}+e^{\frac56x}-2e^{\frac12x}}{x(e^x-1)}\ dx`, 0],
+  [String.raw`\int_0^\infty\frac{x^2e^{\frac12x}}{e^x+1}\ dx`, 0],
+  [String.raw`\int_0^\infty\frac{1-\text{tanh}x}{\sqrt{\text{tanh}x}}\ dx`, 0],
+  [String.raw`\int_0^\infty\frac{\sin \log \tan x}{\log \tan x}\ dx`, 0],
+  [String.raw`\int_0^\infty\frac1{\sqrt{x}(x+1)}\ dx`, 0],
+  [String.raw`\int_0^1 \frac{\log x}{\sqrt{x}(1+x)}\ dx`, 0],
+  [String.raw`\int\prod_{i=0}^n\frac1{\log^ix}\ dx`, 0],
+  [String.raw`\int_0^{\frac{\pi}2}\frac{\cos \log \tan x\log \cos x}{\sin^2 x} \ dx`, 0],
+  [String.raw`\int_0^1 x\log \log \frac1x \ dx`, 0],
+  [String.raw`\int_{\frac{\pi}4}^{\frac{\pi}2}\frac{\cos x\sqrt{\log \tan x}}{\sin^3x}\ dx`, 0],
+  [String.raw`\int_0^\infty\frac{\log x\log (1+x)}{x(1+x)}\ dx`, 0],
+  [String.raw`\int_0^1 \frac{\log x\log (1+x)}{x(1-x)}\ dx`, 0],
+  [String.raw`\int_0^{\frac{\pi}2}\frac{\log \cos x}{\tan x}\ dx`, 0],
+  [String.raw`\int_0^\infty\frac{x\log \text{tanh}x}{\text{tanh}x }\ dx`, 0],
+  [String.raw`\int_0^{\frac1{\sqrt{3}}}\frac{x\text{arctan}x}{(1-x^2)\sqrt{1-2x^2}}\ dx`, 0],
+  [String.raw`\int_0^{\pi}\log\left(\frac54+\cos x\right)\ dx`, 0],
+  [String.raw`\int_0^\infty\sqrt{-\log(1-e^x)}\ dx`, 0],
+  [String.raw`\int_0^2\frac1{(x+2)\sqrt{x+1}} dx`, 0],
+  [String.raw`\int_1^2 \frac1{x\sqrt{1-\log^2x}} dx`, 0]
 ];

--- a/App/integrals/index.html
+++ b/App/integrals/index.html
@@ -21,14 +21,13 @@
 		<main>
 				<p class="title">ランダム積分</p>
 				<div class="box">
-					<button id="fnc" onclick="fnc()">表示</button>
+					<button id="show">表示</button>
 					<div id="eq">$$\displaystyle \int \mathrm{Let}'(s,\ \mathrm{integral}!)\ ds$$</div>
 					<div id="answer">解説：<a id="link" href="">Link</a></div>
 				</div>
 				<a class="about" href="about.html">詳細情報</a>
 		</main>
-		<script src="integrals.js"></script>
-		<script src="data.js" type="module"></script>
+		<script src="integrals.js" type="module"></script>
 		<script>
 		  renderMathInElement(
 		    document.body,

--- a/App/integrals/integrals.js
+++ b/App/integrals/integrals.js
@@ -1,4 +1,4 @@
-import {data} from './data';
+import {data} from './data.js';
 
 function fnc() {
   let equation = document.getElementById('eq');
@@ -6,7 +6,7 @@ function fnc() {
 
   // 問題表示
   let num = Math.floor( Math.random() * data.length ); // integrals の要素の番号をランダムに選ぶ
-  equation.innerHTML = data[num][0];
+  equation.innerHTML = '$$' + data[num][0] + '$$';
 
   // 解説表示
   document.getElementById('answer').style.display = 'block';
@@ -29,3 +29,5 @@ function fnc() {
     }
   );
 }
+
+document.getElementById('show').onclick = fnc;


### PR DESCRIPTION
- `index.html`: To load a javascript file which contains `import` statements, add `type="module"` to the `<script>` tag.
- `integrals.js`: To import a single javascript file with `import` statement, specify the exact name of the file (with the extension `.js`).
- `index.html`: You don't have to load `data.js` in `index.html`, because it is directly imported in `integrals.js`
- `index.html`, `integrals.js`: Since `index.html` loads `integrals.js` as a module, the function `fnc()` defined in `integrals.js` cannot be called in `index.html`. To add a function in the `onclick` attribute of a button, use `document.getElementById('<id>').onclick` instead.
- `data.js`: `let` is needed after `export`
- `data.js`: `\` is the escape character in string literals `` `...` ``. Use ``String.raw`...` `` to avoid the escape.
- `integrals.js`: enclose mathematical expressions with `$$` so that KaTeX renders them.